### PR TITLE
Fix the default accept/content-type headers

### DIFF
--- a/src/common/path-default-params.js
+++ b/src/common/path-default-params.js
@@ -4,11 +4,11 @@ function pathDefaultParams(variants) {
     const header = {};
 
     if (consume) {
-      header.accept = `"${consume}"`;
+      header["Content-Type"] = `"${produce}"`;
     }
 
     if (produce) {
-      header["Content-Type"] = `"${produce}"`;
+      header.accept = `"${consume}"`;
     }
 
     if (Object.keys(header).length) {


### PR DESCRIPTION
The header `accept` represents the response content type (i.e. the produce in the code).
The header `Content-Type` represents the request content type (i.e. the consume in the code).